### PR TITLE
Adds support for bookshop lists and closes #2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,5 @@
+## Version 2.0.0
+- Adds `bookshoplist` as a shortcode with just the slug passed in.
+
 ## Version 1.0.1
 - Fixed that I needed `.Site.Params` not `.Params` in the shortcode.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can also use the Bookshop.org widgets. This requires a little more work, and
 or
 
 ```html
-{{ bookshop 9781524760380 book_button >}} 
+{{< bookshop 9781524760380 book_button >}} 
 ```
 
 Which will turn into the `book` or `book_button` widgets they offer with the correct embed code. 
@@ -42,3 +42,11 @@ You can also use named parameters, of which there are two:
 - `type` which indicates which embed, book or book_button you want.
 
 When not specifying the `type` by name or as the second parameter, you must wrap the link text you want to use in this shortcode or nothing will appear on your site.
+
+### Lists
+
+Bookshop now supports list widgets. After considering overloading the `bookshop` shortcode with a `type="list"`, I decided to support this with a separate shortcode. This way the `bookshop` shortcode always supports widgets related to a single book. With this new shortcode, you only need to supply the slug for your list:
+
+```html
+{{< bookshoplist read-2022-a28bc91a-fc4a-4573-bfa4-15c42345ca33 >}}
+```

--- a/layouts/shortcodes/bookshoplist.html
+++ b/layouts/shortcodes/bookshoplist.html
@@ -1,0 +1,5 @@
+<script src="https://bookshop.org/widgets.js"
+        data-type="list" 
+        data-list-slug="{{ .Get 0 }}">
+</script>
+          

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "2.0.0",
   "title": "Bookshop",
   "description": "Adds the ability to get affiliate links and widgets from Bookshop",
   "fields" :[


### PR DESCRIPTION
Why:

* Support for a new widget type was requested.
* This widget type requires a URL slug versus an ISBN like other types.

This change addresses the need by:

* Creating a fresh shortcode to keep the existing one simpler.
* Allows for just using the slug without named parameters for lists.